### PR TITLE
Fix for the superclustering

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronProducers/plugins/BuildFile.xml
@@ -16,6 +16,7 @@
 <use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
+<use   name="RecoParticleFlow/PFClusterTools"/>
 <use   name="hepmc"/>
 <use   name="clhep"/>
 <use   name="root"/>


### PR DESCRIPTION
Hi Rob, 
The problem was that a supercluster needs cluster (bad things will happen otherwise) there was still a case where this was happening. I also changed the supercluster to be purely cluster based, it shouldnt depend on track quanitities (its fine to use track info to find clusters but it still needs to be just clusters). 

Theres still a problem, the matching is too loose, we suck up what seems like the entire detector into a supercluster which is problematic. Also to note for later:

1) we probably need some sort of uniqueness requirement on clusters not being part of two superclusters (specifically seed clusters)
2) we need to also write out the PFClusters (typically as calo clusters) of the supercluster in a collection as well (we drop PF Clusters from the even in AOD but we can keep clusters in superclusters)
3) general clean ups to confirm to CMS coding standards

Anyway this is a good start! I've got some nice promising plots I'll share with you. 

