### PR TITLE
Changing PreId maps to key off track not electron seed

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.h
@@ -28,7 +28,7 @@ class LowPtGsfElectronSeedProducer final : public edm::stream::EDProducer< edm::
 {
   
  public:
-  
+  using TrackIndxMap = std::unordered_map<reco::TrackRef::key_type,size_t>;
   explicit LowPtGsfElectronSeedProducer( const edm::ParameterSet&, 
 					 const lowptgsfeleseed::HeavyObjectCache* );
 
@@ -55,8 +55,7 @@ class LowPtGsfElectronSeedProducer final : public edm::stream::EDProducer< edm::
 				   reco::ElectronSeedCollection& seeds,
 				   reco::PreIdCollection& ecalPreIds, 
 				   reco::PreIdCollection& hcalPreIds,
-				   std::vector<reco::PreIdRef>& preIdsValueMap,
-				   const edm::RefProd<reco::PreIdCollection>& preIdsRefProd,
+				   TrackIndxMap& trksToPreIdIndx,
 				   edm::Event&,
 				   const edm::EventSetup& );
 
@@ -88,6 +87,11 @@ class LowPtGsfElectronSeedProducer final : public edm::stream::EDProducer< edm::
 			     std::vector<int>& matchedHcalClusters,
 			     reco::PreId& ecalPreId, 
 			     reco::PreId& hcalPreId );
+  template<typename CollType>
+  void fillPreIdRefValueMap( edm::Handle<CollType> tracksHandle,
+			     const TrackIndxMap& trksToPreIdIndx,
+			     const edm::OrphanHandle<reco::PreIdCollection>& preIdHandle,
+			     edm::ValueMap<reco::PreIdRef>::Filler & filler);
 
   // Overloaded methods to evaluate BDTs (using PF or KF tracks)
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedValueMapsProducer.cc
@@ -51,8 +51,8 @@ void LowPtGsfElectronSeedValueMapsProducer::produce( edm::Event& event, const ed
 	 ele->core()->gsfTrack()->extra().isNonnull() && 
 	 ele->core()->gsfTrack()->extra()->seedRef().isNonnull() ) {
       reco::ElectronSeedRef seed = ele->core()->gsfTrack()->extra()->seedRef().castTo<reco::ElectronSeedRef>();
-      if ( seed.isNonnull() ) {
-	const reco::PreIdRef preid = (*preIdsValueMap)[seed];
+      if ( seed.isNonnull() && seed->ctfTrack().isNonnull() ) {
+	const reco::PreIdRef preid = (*preIdsValueMap)[seed->ctfTrack()];
 	if ( preid.isNonnull() ) {
 	  for ( unsigned int iname = 0; iname < names_.size(); ++iname ) {
 	    output[iname][iele] = preid->mva(iname);


### PR DESCRIPTION
Hi Rob,

This changes the PreID to seed off the track not electron seed and so automatically fixes the fast sim issues. 

Running full tests now but wanted to give it to you now

Best,
Sam